### PR TITLE
VSIX manifest cleanup

### DIFF
--- a/Tvl.VisualStudio.MouseFastScroll/source.extension.vsixmanifest
+++ b/Tvl.VisualStudio.MouseFastScroll/source.extension.vsixmanifest
@@ -11,7 +11,7 @@
     <ReleaseNotes>https://github.com/tunnelvisionlabs/MouseFastScroll/releases/tag/v3.0.1</ReleaseNotes>
     <!--<Icon></Icon>-->
     <!--<PreviewImage></PreviewImage>-->
-    <!--<Tags></Tags>-->
+    <Tags>mouse, scroll, zoom</Tags>
   </Metadata>
   <Installation>
     <InstallationTarget Version="[11.0,15.0)" Id="Microsoft.VisualStudio.Community" />

--- a/Tvl.VisualStudio.MouseFastScroll/source.extension.vsixmanifest
+++ b/Tvl.VisualStudio.MouseFastScroll/source.extension.vsixmanifest
@@ -6,7 +6,8 @@
     <Description>Use Ctrl+Mouse Wheel for fast and easy Page Up/Down scrolling.</Description>
     <MoreInfo>https://github.com/tunnelvisionlabs/MouseFastScroll</MoreInfo>
     <License>LICENSE.txt</License>
-    <GettingStartedGuide>https://marketplace.visualstudio.com/items?itemName=SamHarwell.MouseFastScroll</GettingStartedGuide>
+    <!-- Don't include the GettingStartedGuide because it makes a web browser pop up after installation -->
+    <!--<GettingStartedGuide>https://marketplace.visualstudio.com/items?itemName=SamHarwell.MouseFastScroll</GettingStartedGuide>-->
     <ReleaseNotes>https://github.com/tunnelvisionlabs/MouseFastScroll/releases/tag/v3.0.1</ReleaseNotes>
     <!--<Icon></Icon>-->
     <!--<PreviewImage></PreviewImage>-->


### PR DESCRIPTION
* Remove the `<GettingStartedGuide>` element so no web browser pops up after installation
* Add the `<Tags>` element