### PR TITLE
Allow execution of lambda expressions inside Visual Studio process

### DIFF
--- a/Tvl.VisualStudio.MouseFastScroll.IntegrationTests/ExecutorTests.cs
+++ b/Tvl.VisualStudio.MouseFastScroll.IntegrationTests/ExecutorTests.cs
@@ -1,0 +1,50 @@
+﻿namespace Tvl.VisualStudio.MouseFastScroll.IntegrationTests
+{
+    using System;
+    using System.IO;
+    using EnvDTE;
+    using Xunit;
+
+    public abstract class ExecutorTests : AbstractIntegrationTest
+    {
+        protected ExecutorTests(VisualStudioInstanceFactory instanceFactory, Version version)
+            : base(instanceFactory, version)
+        {
+        }
+
+        [VersionTrait(typeof(VS2015))]
+        public sealed class VS2015 : ExecutorTests
+        {
+            public VS2015(VisualStudioInstanceFactory instanceFactory)
+                : base(instanceFactory, Versions.VisualStudio2015)
+            {
+            }
+
+            [Fact]
+            public void ReturnLocal()
+            {
+                var local = "local";
+
+                var ret = VisualStudio.ExecuteInHostProcess(() => local);
+
+                Assert.Equal(local, ret);
+            }
+
+            [Fact]
+            public void ReturnLiteral()
+            {
+                var ret = VisualStudio.ExecuteInHostProcess(() => "literal");
+
+                Assert.Equal("literal", ret);
+            }
+
+            [Fact]
+            public void ReturnFromDte()
+            {
+                var file = VisualStudio.ExecuteInHostProcess((DTE dte) => dte.FileName);
+
+                Assert.True(File.Exists(file));
+            }
+        }
+    }
+}

--- a/Tvl.VisualStudio.MouseFastScroll.IntegrationTests/Executor_InProc.cs
+++ b/Tvl.VisualStudio.MouseFastScroll.IntegrationTests/Executor_InProc.cs
@@ -1,0 +1,59 @@
+﻿namespace Tvl.VisualStudio.MouseFastScroll.IntegrationTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using EnvDTE;
+
+    internal class Executor_InProc : InProcComponent
+    {
+        private Executor_InProc()
+        {
+        }
+
+        public static Executor_InProc Create()
+            => new Executor_InProc();
+
+        public object Execute(string assemblyFile, string typeName, string methodName, Dictionary<string, object> fieldValues)
+        {
+            var assembly = Assembly.LoadFrom(assemblyFile);
+            var type = assembly.GetType(typeName);
+            var obj = Activator.CreateInstance(type);
+            foreach (var field in type.GetFields())
+            {
+                var name = field.Name;
+                if (!name.StartsWith("<>"))
+                {
+                    var value = fieldValues[name];
+                    field.SetValue(obj, value);
+                }
+            }
+
+            var method = type.GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            var args = GetArguments(method);
+            return method.Invoke(obj, args);
+        }
+
+        private object[] GetArguments(MethodInfo method)
+        {
+            var parameters = method.GetParameters();
+            var args = new object[parameters.Length];
+            for (int n = 0; n < args.Length; n++)
+            {
+                args[n] = GetService(parameters[n].ParameterType);
+            }
+
+            return args;
+        }
+
+        private object GetService(Type type)
+        {
+            if (type == typeof(DTE))
+            {
+                return GetDTE();
+            }
+
+            throw new ApplicationException($"Service interface of type '{type.FullName}' not supported");
+        }
+    }
+}

--- a/Tvl.VisualStudio.MouseFastScroll.IntegrationTests/Executor_OutOfProc.cs
+++ b/Tvl.VisualStudio.MouseFastScroll.IntegrationTests/Executor_OutOfProc.cs
@@ -1,0 +1,55 @@
+﻿namespace Tvl.VisualStudio.MouseFastScroll.IntegrationTests
+{
+    using System;
+    using System.Collections.Generic;
+
+    public class Executor_OutOfProc : OutOfProcComponent
+    {
+        internal Executor_OutOfProc(VisualStudioInstance visualStudioInstance)
+            : base(visualStudioInstance)
+        {
+            ExecutorInProc = CreateInProcComponent<Executor_InProc>(visualStudioInstance);
+        }
+
+        internal Executor_InProc ExecutorInProc
+        {
+            get;
+        }
+
+        public void Execute(Action method) => Execute(method);
+
+        internal TResult Execute<TResult>(InProcComponent remote, Func<TResult> method)
+            => (TResult)Execute(method);
+
+        internal TResult Execute<T, TResult>(InProcComponent remote, Func<T, TResult> method)
+            => (TResult)Execute(method);
+
+        private object Execute(Delegate method)
+        {
+            var target = method.Target;
+            var methodName = method.Method.Name;
+            var targetType = target.GetType();
+            var assemblyFile = targetType.Assembly.Location;
+            var typeName = targetType.FullName;
+            var localValues = GetLocalValues(target);
+            return ExecutorInProc.Execute(assemblyFile, typeName, methodName, localValues);
+        }
+
+        private static Dictionary<string, object> GetLocalValues(object target)
+        {
+            var targetType = target.GetType();
+            var localValues = new Dictionary<string, object>();
+            foreach (var field in targetType.GetFields())
+            {
+                var name = field.Name;
+                if (!name.StartsWith("<>"))
+                {
+                    var value = field.GetValue(target);
+                    localValues[name] = value;
+                }
+            }
+
+            return localValues;
+        }
+    }
+}


### PR DESCRIPTION
I wanted to allow the execution of arbitrary expressions inside the Visual Studio process, without having to write any boilerplate code (e.g. in-proc and out-of-proc methods).

This PR expands what it accepted by the `VisualStudio.ExecuteInHostProcess` method.

For example, you can retrieve the `DTE.Version` like this:
```
var version = VisualStudio.ExecuteInHostProcess((DTE dte) => dte.Version);
```

This is superficially similar to the following:
```
var version = VisualStudioInstance.RetryRpcCall(() => VisualStudio.Dte.Version);
```

Executing the expression inside the host process is useful for more complex expressions that often don't via an RPC call. For example you can do this:
```
var visible = VisualStudio.ExecuteInHostProcess((DTE dte) => dte.Windows.Item("Output").Visible);
```

This implementation also supports passing in locals. This means the following would also work:
```
var name = "Output";
var visible = VisualStudio.ExecuteInHostProcess((DTE dte) =>
    dte.Windows.Item(name).Visible);
```

This can then be encapsulated as:
```
private bool IsWindowVisible(string name)
    => VisualStudio.ExecuteInHostProcess((DTE dte) => dte.Windows.Item(name).Visible);
```

At the moment only `DTE` parameters are supported, the the idea is to also support `IServiceProvider` and other services.

Do you think this would be useful?