### PR TITLE
Add support for VS2022 on ARM64

### DIFF
--- a/Tvl.VisualStudio.MouseFastScroll/Tvl.VisualStudio.MouseFastScroll.csproj
+++ b/Tvl.VisualStudio.MouseFastScroll/Tvl.VisualStudio.MouseFastScroll.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.2155-preview2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.6.2164" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="all" />
   </ItemGroup>
 

--- a/Tvl.VisualStudio.MouseFastScroll/source.extension.vsixmanifest
+++ b/Tvl.VisualStudio.MouseFastScroll/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="Tvl.VisualStudio.MouseFastScroll.7DFA0DD1-8052-464D-9A1A-5EADC10A84B0" Version="4.4.0" Language="en-US" Publisher="Sam Harwell" />
+    <Identity Id="Tvl.VisualStudio.MouseFastScroll.7DFA0DD1-8052-464D-9A1A-5EADC10A84B0" Version="4.4.1" Language="en-US" Publisher="Sam Harwell" />
     <DisplayName>Mouse Fast Scroll</DisplayName>
     <Description>Use Ctrl+Mouse Wheel for fast and easy Page Up/Down scrolling.</Description>
     <MoreInfo>https://github.com/tunnelvisionlabs/MouseFastScroll</MoreInfo>

--- a/Tvl.VisualStudio.MouseFastScroll/source.extension.vsixmanifest
+++ b/Tvl.VisualStudio.MouseFastScroll/source.extension.vsixmanifest
@@ -23,6 +23,9 @@
     <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
       <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
+    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+      <ProductArchitecture>arm64</ProductArchitecture>
+    </InstallationTarget>
   </Installation>
   <Prerequisites>
     <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,18.0)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
This adds support for VS 2022 running on ARM64 architecture.

Edit: I know about the build errors but I thought it would be cleaner for this PR to be based off the main branch.   I have tested the changes along with #35 and it appears to compile/install as expected.

Fixes #36